### PR TITLE
fixed wrong printf specifier

### DIFF
--- a/calculator.c
+++ b/calculator.c
@@ -111,7 +111,7 @@ int main(void)
              printf("%g is larger than %g.\n", num2, num1);
 
         srand(time(NULL));
-        printf("Random number of the day is:  %g\n", rand());
+        printf("Random number of the day is:  %i\n", rand());
         puts("----------------------------------");
     }
     return 0;


### PR DESCRIPTION
`rand()` returns a signed integer, but `%g` is for floating-point stuff.

Yay for compiler warnings.
