### PR TITLE
possible warning on some compilers

### DIFF
--- a/calculator.c
+++ b/calculator.c
@@ -58,7 +58,7 @@ int main(void)
 {
     double num1, num2;
     
-    while (1)
+    for (;;)
     {
         fputs("Please enter a number: ", stdout);
         num1 = carry_in();


### PR DESCRIPTION
Some compilers throw a warning saying "conditional expression is constant", but GCC with just -Wall -pedantic seems to tolerate the `while (1)`.

Another thing I don't really like about `while (1)` is that the 1 is more of an arbitrary non-zero truth value compared to `while (true)`, which looks a little more clean but is more of a C99 thing anyway.  In practice, I see the `for (;;)` solution as a more neutral one.
