### PR TITLE
new function for taking nth roots of any decimal

### DIFF
--- a/calculator.c
+++ b/calculator.c
@@ -30,9 +30,29 @@ double divide(double m, double n)
 #endif
     return (m / n);
 }
+
 double power(double m, double n)
 {
     return pow(m, n);
+}
+double root(double radicand, double index)
+{
+    double scientific; /* index * 10^x, until it becomes an integer */
+    long i; /* index as an integer... 8 ^ (5/3) = cuberoot(8 ^ 5) */
+
+    if (radicand == 0)
+        return 0; /* divide(0, 0) is too abstract and could be anything. */
+    if (index == 0)
+        return divide(radicand, 0);
+
+    scientific = index;
+    while (scientific != (double)((long int)scientific))
+        scientific *= 10;
+    i = (signed long)scientific;
+
+    if (radicand < 0 && i % 2 != 0) /* odd-roots of negative numbers */
+        return -power(-radicand, 1 / index);
+    return power(radicand, 1 / index);
 }
 
 unsigned long factorial(unsigned long n)

--- a/calculator.h
+++ b/calculator.h
@@ -10,6 +10,8 @@ double multiply(double m, double n);
 double divide(double m, double n);
 
 double power(double m, double n);
+double root(double radicand, double index); /* basically power(m, 1/n) */
+
 extern unsigned long factorial(unsigned long n);
 
 /*

--- a/main.c
+++ b/main.c
@@ -11,7 +11,7 @@
 #include <time.h>
 
 static const char operators[] = {
-    '+', '-', '*', '/', '^',
+    '+', '-', '*', '/', '^', 'R',
 };
 
 const op_ptr functions[] = {
@@ -19,7 +19,9 @@ const op_ptr functions[] = {
     subtract,
     multiply,
     divide,
+
     power,
+    root,
 };
 
 int main(void)
@@ -46,12 +48,12 @@ int main(void)
         if (num1 < 0)
             puts("Error: cannot find the square root of a number less than 0");
         else
-            printf("The square root of %g is %g.\n", num1, sqrt(num1));
+            printf("The square root of %g is %g.\n", num1, root(num1, 2));
 
         if (num2 < 0)
             puts("Error: cannot find the square root of a number less than 0");
         else
-            printf("The square root of %g is %g.\n", num2, sqrt(num2));
+            printf("The square root of %g is %g.\n", num2, root(num2, 2));
 
 /*
  * integer-precision factorials


### PR DESCRIPTION
In general, square roots are just pow(x, 1/2), cube roots are pow(x, 1/3), etc..

So why do we need a `root()` function?

Well one reason is odd roots of negative numbers, like cbrt(-8).
Simply taking cuberoot(-8) = pow(-8, 1/3) just approximates 1.333330 or whatever, which technically is an even root not an odd root, due to truncation of infinitely repeating decimal points.  (JavaScript's `Math.power` class member has a similar fundamental limitation.)

Things like that and other corner cases is why I thought a function would be more convenient.
