### PR TITLE
unified integer types to a central size definition

### DIFF
--- a/calculator.c
+++ b/calculator.c
@@ -6,6 +6,7 @@
 
 #include <float.h>
 #include <math.h>
+#include "calculator.h"
 
 double add(double m, double n)
 {
@@ -38,7 +39,7 @@ double power(double m, double n)
 double root(double radicand, double index)
 {
     double scientific; /* index * 10^x, until it becomes an integer */
-    long i; /* index as an integer... 8 ^ (5/3) = cuberoot(8 ^ 5) */
+    integer i; /* e.g. 8 ^ (5/3) = cuberoot(8 ^ 5), so i = 3 */
 
     if (radicand == 0)
         return 0; /* divide(0, 0) is too abstract and could be anything. */
@@ -46,19 +47,19 @@ double root(double radicand, double index)
         return divide(radicand, 0);
 
     scientific = index;
-    while (scientific != (double)((long int)scientific))
+    while (scientific != (double)((integer)scientific))
         scientific *= 10;
-    i = (signed long)scientific;
+    i = (integer)scientific;
 
     if (radicand < 0 && i % 2 != 0) /* odd-roots of negative numbers */
         return -power(-radicand, 1 / index);
     return power(radicand, 1 / index);
 }
 
-unsigned long factorial(unsigned long n)
+whole factorial(whole n)
 {
-    unsigned long answer, old_answer;
-    unsigned long i;
+    whole answer, old_answer;
+    whole i;
 
     answer = 1;
     for (i = 1; i < n + 1; i++)

--- a/calculator.h
+++ b/calculator.h
@@ -1,6 +1,30 @@
 #ifndef _CALCULATOR_H_
 #define _CALCULATOR_H_
 
+/*
+ * Try to take advantage of the C implementation to provide the best
+ * (highest-precision) integer types--preferably in a C89-compliant way.
+ *
+ * A `whole' number is a non-negative integer.  This is an important type to
+ * have for operations like !x (factorial), which cannot return for (x < 0).
+ */
+#include <limits.h>
+#include <stddef.h>
+
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)
+typedef long long               integer;
+typedef unsigned long long      whole;
+#elif (ULONG_MAX > 0x00000000FFFFFFFFul)
+typedef signed long             integer;
+typedef unsigned long           whole;
+#elif defined(INT64_MIN) && defined(INT64_MAX) && defined(UINT64_MAX)
+typedef int64_t                 integer;
+typedef uint64_t                whole;
+#else
+typedef long int                integer;
+typedef size_t                  whole;
+#endif
+
 typedef double(*op_ptr)(double m, double n);
 extern const op_ptr functions[];
 
@@ -12,7 +36,7 @@ double divide(double m, double n);
 double power(double m, double n);
 double root(double radicand, double index); /* basically power(m, 1/n) */
 
-extern unsigned long factorial(unsigned long n);
+extern whole factorial(whole n);
 
 /*
  * string-to-number input conversion replacement for C++ cout and cin

--- a/main.c
+++ b/main.c
@@ -62,13 +62,13 @@ int main(void)
             printf(
                 "The factorial of %lu is %lu.\n",
                 (unsigned long)num1,
-                factorial((unsigned long)num1)
+                (unsigned long)factorial((whole)num1)
             );
         if (num2 >= 0)
             printf(
                 "The factorial of %lu is %lu.\n",
                 (unsigned long)num2,
-                factorial((unsigned long)num2)
+                (unsigned long)factorial((whole)num2)
             );
 
         printf("%g to the power of %g is %g.\n", num2, num1, power(num2, num1));


### PR DESCRIPTION
Usually `unsigned long` is beyond large enough, but there are ways to do math on integers stored in C types whose sizes transcend the physical limits of the CPU's register sizes.  (For example, on 32-bit x86 the C99 type `long long` is 64-bit, even though the physical register limit is 32-bit which would be `long` in that case.)

So maybe it would be best to keep maintainable type definitions for a generic `integer` type.  The same goes for its unsigned counterpart, `whole`.  (There is some philosophical debate on whether or not whole numbers should include negativeintegers, but the standard consensus is that this class is ignored.)

May do a similar PR for changing `double` into a custom typedef soon as well.
