### PR TITLE
unified floating-point real number typedef

### DIFF
--- a/calculator.c
+++ b/calculator.c
@@ -8,19 +8,19 @@
 #include <math.h>
 #include "calculator.h"
 
-double add(double m, double n)
+real add(real m, real n)
 {
     return (m + n);
 }
-double subtract(double m, double n)
+real subtract(real m, real n)
 {
     return (m - n);
 }
-double multiply(double m, double n)
+real multiply(real m, real n)
 {
     return (m * n);
 }
-double divide(double m, double n)
+real divide(real m, real n)
 {
 #ifndef PREFER_NATIVE_HARDWARE_DIVISION_BY_ZERO
     if (n == 0) /* Undefined, but we must return (something). */
@@ -32,24 +32,24 @@ double divide(double m, double n)
     return (m / n);
 }
 
-double power(double m, double n)
+real power(real m, real n)
 {
     return pow(m, n);
 }
-double root(double radicand, double index)
+real root(real radicand, real index)
 {
-    double scientific; /* index * 10^x, until it becomes an integer */
-    integer i; /* e.g. 8 ^ (5/3) = cuberoot(8 ^ 5), so i = 3 */
+    real mantissa; /* index * 10^x, until it becomes an integer */
+    integer i;
 
     if (radicand == 0)
         return 0; /* divide(0, 0) is too abstract and could be anything. */
     if (index == 0)
         return divide(radicand, 0);
 
-    scientific = index;
-    while (scientific != (double)((integer)scientific))
-        scientific *= 10;
-    i = (integer)scientific;
+    mantissa = index;
+    while (mantissa != (real)((integer)mantissa))
+        mantissa *= 10;
+    i = (integer)mantissa;
 
     if (radicand < 0 && i % 2 != 0) /* odd-roots of negative numbers */
         return -power(-radicand, 1 / index);

--- a/calculator.h
+++ b/calculator.h
@@ -1,6 +1,13 @@
 #ifndef _CALCULATOR_H_
 #define _CALCULATOR_H_
 
+#if 0
+typedef long double             real;
+#else
+typedef double                  real;
+#endif
+typedef real (*op_ptr)(real m, real n);
+
 /*
  * Try to take advantage of the C implementation to provide the best
  * (highest-precision) integer types--preferably in a C89-compliant way.
@@ -25,16 +32,15 @@ typedef long int                integer;
 typedef size_t                  whole;
 #endif
 
-typedef double(*op_ptr)(double m, double n);
 extern const op_ptr functions[];
 
-double add(double m, double n);
-double subtract(double m, double n);
-double multiply(double m, double n);
-double divide(double m, double n);
+real add(real m, real n);
+real subtract(real m, real n);
+real multiply(real m, real n);
+real divide(real m, real n);
 
-double power(double m, double n);
-double root(double radicand, double index); /* basically power(m, 1/n) */
+real power(real m, real n);
+real root(real radicand, real index); /* basically power(m, 1/n) */
 
 extern whole factorial(whole n);
 

--- a/main.c
+++ b/main.c
@@ -28,7 +28,7 @@ const op_ptr functions[] = {
 int main(void)
 {
     size_t i;
-    double num1, num2;
+    real num1, num2;
 
     srand(time(NULL));
     for (;;)


### PR DESCRIPTION
This way you can change it to `long double` instead of `double` if you wanted, but I wouldn't.

Maybe "rational" instead of "real" would be the better name for the custom type since computers can't actually store irrational numbers, for all their infinite precision.
