### PR TITLE
Link against math library to resolve pow().

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -28,4 +28,4 @@ as -o $obj/main.o               $obj/main.asm
 as -o $obj/calculator.o         $obj/calculator.asm
 
 echo Linking assembled object files...
-gcc -o $src/calc $obj/calculator.o $obj/main.o -s
+gcc -o $src/calc $obj/calculator.o -lm $obj/main.o -s


### PR DESCRIPTION
Undefined reference to `pow` when linking on Linux.

The answer is that MinGW GCC does not need `-lm` to link against math library; native GCC does.

Seems Git also tracks my file mode change of `chmod  +x ./make.sh` to the file for execute permissions.
