### PR TITLE
Let system attempt division by 0 before handling exceptions.

### DIFF
--- a/calculator.c
+++ b/calculator.c
@@ -6,6 +6,8 @@
 
 #include <float.h>
 #include <math.h>
+
+#include <signal.h>
 #include "calculator.h"
 
 real add(real m, real n)
@@ -22,13 +24,14 @@ real multiply(real m, real n)
 }
 real divide(real m, real n)
 {
-#ifndef PREFER_NATIVE_HARDWARE_DIVISION_BY_ZERO
-    if (n == 0) /* Undefined, but we must return (something). */
-    {
+    int recovered_from_exception;
+
+    recovered_from_exception = setjmp(CPU_state);
+    if (recovered_from_exception) {
+        signal(SIGFPE, FPU_exception);
         n = DBL_MIN; /* smallest positive real number */
         m = (m < 0) ? -DBL_MAX : +DBL_MAX;
     } /* Geometric graphs of x/0 look prettiest this way. */
-#endif
     return (m / n);
 }
 

--- a/calculator.c
+++ b/calculator.c
@@ -26,6 +26,7 @@ real divide(real m, real n)
 {
     int recovered_from_exception;
 
+    signal(SIGFPE, FPU_exception);
     recovered_from_exception = setjmp(CPU_state);
     if (recovered_from_exception) {
         signal(SIGFPE, FPU_exception);

--- a/calculator.h
+++ b/calculator.h
@@ -18,6 +18,14 @@ typedef real (*op_ptr)(real m, real n);
 #include <limits.h>
 #include <stddef.h>
 
+/*
+ * Set up exception-handling in C in case the user requests funny things.
+ * Division by 0, even-roots of negative numbers, 0 to the power of 0, etc.
+ */
+#include <setjmp.h>
+extern jmp_buf CPU_state;
+extern void FPU_exception(int exception_ID);
+
 #if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)
 typedef long long               integer;
 typedef unsigned long long      whole;


### PR DESCRIPTION
Don't prevent division by 0, negative square roots, pow(0, 0), and other exception-prone operations.

In good programs these should be prevented in C, but in this calculator program I think it's more beneficial to let the hardware and operating system attempt to evaluate these instructions (if not just for the curiosity of observing implementation-defined behavior in the calculations) before catching any exceptions that might be raised and then forcing the result in software.